### PR TITLE
fix: InputManager configuration was nil on initial launch

### DIFF
--- a/scripts/core/input/InputManager.lua
+++ b/scripts/core/input/InputManager.lua
@@ -115,6 +115,7 @@ end
 --- Sets keys codes for each game key.
 -- @tparam MapConfig conf Key configuration.
 function InputManager:setKeyConfiguration(conf)
+  conf = conf or {}
   self.mainMap = {}
   self.altMap = {}
   self.gamepadMap = {}
@@ -413,3 +414,4 @@ function InputManager:onAxisMove(axis, value)
 end
 
 return InputManager
+


### PR DESCRIPTION
fix for issue #2 

When starting the game for the first time, the keyMaps are not set properly. InputManager gets passed a configuration (conf) that is nil, because there is no configuration yet.

This error does not occur, when the keymaps are changed and a configuration json was saved. In that case, the variable is not nil anymore and the keyMap table can be copied over.

How to reproduce bug:
- download source code and put it in a new folder
- run with love